### PR TITLE
User Serialization

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,21 @@
 class UsersController < ApplicationController
 
+    # NOTE: Commented out actions are currently only necessary for development or admin purposes, so leaving out.
+
+    # def index
+    #     users = User.all.order(:id)
+    #     render json: users
+    # end
+
+    # def show
+    #     user = User.find_by(id: params[:id])
+    #     if user
+    #         render json: user
+    #     else
+    #         render json: { error: 'User not found' }, status: :not_found
+    #     end
+    # end
+
     def create
         user = User.find_or_create_by(user_params)
         render json: user

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -11,4 +11,10 @@ class Note < ApplicationRecord
     end
   end
 
+  def tag_names
+    # Read tag names as a comma-separated string of title-cased names
+    titleized_names = self.tags.map { |tag| tag.name.titleize }
+    titleized_names.join(', ')
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
+    has_many :notes
     validates :username, { presence: true, uniqueness: { case_sensitive: false } }
 end

--- a/app/serializers/note_serializer.rb
+++ b/app/serializers/note_serializer.rb
@@ -1,5 +1,4 @@
 class NoteSerializer < ActiveModel::Serializer
-  attributes :id, :title, :content
-  belongs_to :user
+  attributes :id, :title, :content, :user_id
   has_many :tags
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,9 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :username
+  attributes :id, :username, :notes
+
+  def notes
+    ActiveModelSerializers::SerializableResource.new(object.notes,  each_serializer: NoteSerializer)
+    # ActiveModel::SerializableResource.new(object.notes,  each_serializer: NoteSerializer)
+  end
+
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,9 +1,9 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :username, :notes
 
+  # Serialize the notes more than one level deep (i.e. to include serialized tags)
   def notes
     ActiveModelSerializers::SerializableResource.new(object.notes,  each_serializer: NoteSerializer)
-    # ActiveModel::SerializableResource.new(object.notes,  each_serializer: NoteSerializer)
   end
 
 end


### PR DESCRIPTION
Update user serialization to also include the user's notes (including tags). This is better tailored to the narrow scope of the application (simple note storage by user) so that a single API request can be made at user login. 